### PR TITLE
Fix licensing plate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ In various parts of this website, there will be quotations from the Clojure and 
 
 
 
-> *   Clojure
-> *   Copyright (c) Rich Hickey. All rights reserved.
-< *   The use and distribution terms for this software are covered by the
-> *   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
-> *   which can be found in the file LICENSE at the root of this distribution.
-> *   By using this software in any fashion, you are agreeing to be bound by
-> * 	 the terms of this license.
-> *   You must not remove this notice, or any other, from this software.
+## License ##
+
+    Copyright (c) Rich Hickey. All rights reserved. The use and
+    distribution terms for this software are covered by the Eclipse
+    Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+    which can be found in the file epl-v10.html at the root of this
+    distribution. By using this software in any fashion, you are
+    agreeing to be bound by the terms of this license. You must
+    not remove this notice, or any other, from this software.


### PR DESCRIPTION
The rendering was messed up before.

This uses the exact same copy of the ClojureCLR readme.